### PR TITLE
Change senderPublicKey to senderPubData

### DIFF
--- a/lib/api/delegates.js
+++ b/lib/api/delegates.js
@@ -149,7 +149,7 @@ module.exports = function (app) {
 
 		this.getDelegate = function (tx, cb) {
 			cachedRequest({
-				url: `${app.get('lisk address')}/api/delegates/get?publicKey=${tx.senderPublicKey}`,
+				url: `${app.get('lisk address')}/api/delegates/get?publicKey=${tx.senderPubData}`,
 				json: true,
 			}, app.locals.redis, 60, (err, body) => {
 				if (err) {
@@ -208,7 +208,7 @@ module.exports = function (app) {
 
 		this.getDelegate = (tx, cb) => {
 			cachedRequest({
-				url: `${app.get('lisk address')}/api/delegates/get?publicKey=${tx.senderPublicKey}`,
+				url: `${app.get('lisk address')}/api/delegates/get?publicKey=${tx.senderPubData}`,
 				json: true,
 			}, app.locals.redis, 60, (err, body) => {
 				if (err) {


### PR DESCRIPTION
### What was the problem?
rise-node API got `undefined` instead of the `publicKey` since `senderPublicKey` was changed to `senderPubData` in v2.
 
### How did I fix it?
Edited two lines from `senderPublicKey` to `senderPubData`
