### PR TITLE
Change Buffer() to Buffer.alloc()

### DIFF
--- a/lib/api/blocks.js
+++ b/lib/api/blocks.js
@@ -145,7 +145,7 @@ module.exports = function (app) {
 			const b = body.block;
 
 			b.confirmations = (height - b.height) + 1;
-			b.payloadHash = new Buffer.alloc(b.payloadHash).toString('hex');
+			b.payloadHash = new Buffer.alloc(b.payloadHash, 'hex');
 
 			return body;
 		};

--- a/lib/api/blocks.js
+++ b/lib/api/blocks.js
@@ -145,7 +145,7 @@ module.exports = function (app) {
 			const b = body.block;
 
 			b.confirmations = (height - b.height) + 1;
-			b.payloadHash = new Buffer(b.payloadHash).toString('hex');
+			b.payloadHash = new Buffer.alloc(b.payloadHash).toString('hex');
 
 			return body;
 		};


### PR DESCRIPTION
### What was the problem?
Deprecated warning because of `Buffer()` which should be updated to `Buffer.alloc()`.

### How did I fix it?
Changed `Buffer()` to `Buffer.alloc()`.
