### PR TITLE
Added Type to newBlock in statistics.js

### DIFF
--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -60,6 +60,11 @@ module.exports = function (app) {
 				if (this.volume.blocks >= this.maxCount) { break; }
 
 				const newBlock = blocks[i];
+                                newBlock.totalAmount = Number(newBlock.totalAmount);
+                                newBlock.totalFee = Number(newBlock.totalFee);
+                                newBlock.reward = Number(newBlock.reward);
+                                newBlock.totalForged = Number(newBlock.totalForged);
+
 				const newAmount = (newBlock.totalAmount + newBlock.totalFee);
 
 				this.volume.blocks += 1;


### PR DESCRIPTION
### What was the problem?
In Node version 10, we need to add Type to counter the `undefined`. 

### How did I fix it?
The errors were fixed by adding a `Number()` type. 
