### PR TITLE
Changed blockTime to the appropriate 30 seconds

### DIFF
--- a/config.global.js
+++ b/config.global.js
@@ -14,7 +14,7 @@
  *
  */
 const config = {};
-config.blockTime = 27;
+config.blockTime = 30;
 config.lisk = {};
 config.freegeoip = {};
 config.redis = {};


### PR DESCRIPTION
### What was the problem?
`blockTime` was incorrect. 

### How did I fix it?
Changed `blockTime` to the appropriate `30 seconds`
