### PR TITLE
Changed port to 5555 instead of 4000

### DIFF
--- a/config.js
+++ b/config.js
@@ -25,7 +25,7 @@ config.port = 6040; // Port to listen on
  * LISK node
  */
 config.lisk.host = process.env.LISK_HOST || '127.0.0.1';
-config.lisk.port = process.env.LISK_PORT || 4000;
+config.lisk.port = process.env.LISK_PORT || 5555;
 
 /**
  * FreeGeoIP server


### PR DESCRIPTION
### What was the problem?
`Port` reflected LISK instead of RISE.
 
### How did I fix it?
Changed `port` from `4000` to `5555`.
