### PR TITLE
Change logo title from Lisk to RISE

### DIFF
--- a/src/components/header/header.html
+++ b/src/components/header/header.html
@@ -21,7 +21,7 @@
 			<div id="header" role="navigation" class="navbar navbar-default">
 				<div class="logo-wrapper">
 					<a href="/">
-						<figure class="logo" title="Lisk">
+						<figure class="logo" title="RISE">
 							<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 50 96">
 								<metadata><?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
 									<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.6-c138 79.159824, 2016/09/14-01:09:01        ">


### PR DESCRIPTION
### What was the problem?
Wrong project name on mouseover logo.

### How did I fix it?
Changed logo title from Lisk to RISE.
